### PR TITLE
Support cross-realm monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ public/webpack/
 /keytabs/
 /volumes/
 
+# Random tempdir
+/tmp/
+
 # IDE
 .idea/
 /public/output.css

--- a/public/index.html
+++ b/public/index.html
@@ -36,8 +36,13 @@
           <input class="fpl-input" id="password" type="password" size="50">
         </label>
 
-        <div class="text-xs text-gray-400">These credentials will need to have global debugger rights to see much
-          of interest.
+        <div class="text-xs text-gray-400">
+            <p>These credentials will need to have global debugger
+            rights to see much of interest.
+            <p>To monitor multiple brokers at the same time, give a
+            space-separated list of Directory URLs. The username
+            will need to be the full Kerberos principal name of
+            an account with cross-realm access to all the brokers.
         </div>
 
         <label class="text-gray-500 font-medium flex items-center">

--- a/public/mqttclient.js
+++ b/public/mqttclient.js
@@ -38,6 +38,7 @@ export default class MQTTClient extends EventEmitter {
 
     stop () {
         clearInterval(this.expiry_timer);
+        if (!this.mqtt) return;
         return new Promise((resolve, reject) => {
             this.mqtt.on("end", resolve);
             this.mqtt.end();

--- a/public/mqttclient.js
+++ b/public/mqttclient.js
@@ -12,11 +12,14 @@ export default class MQTTClient extends EventEmitter {
     constructor (opts) {
         super();
         this.fplus = opts.fplus;
-        this.icons = opts.icons;
+        this.graph = opts.graph;
 
         this.known = new Map();
-        this.graph = {
-            name: opts.name,
+    }
+
+    static graph (name) {
+        return {
+            name,
             online: true,
         };
     }
@@ -116,7 +119,7 @@ export default class MQTTClient extends EventEmitter {
 
         //console.log("Found schema %s for %s", schema, node.name);
         node.schema = schema;
-        this.icons.request_icon(schema);
+        this.emit("schema", schema);
     }
 
     async check_directory (address, node) {
@@ -134,7 +137,7 @@ export default class MQTTClient extends EventEmitter {
         if (node.seen_birth) return;
         
         node.schema = info.top_schema;
-        this.icons.request_icon(node.schema);
+        this.emit("schema", node.schema);
     }
 
     on_expiry () {


### PR DESCRIPTION
Support connecting to multiple brokers and displaying all the devices on a single graph.

This relies on cross-realm auth having been set up between the F+ instances.